### PR TITLE
Fix shell script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-go build -o ../bin/main ../src/*.go
+DIR=$(dirname "${BASH_SOURCE[0]}")
+go build -o $DIR/../bin/main $DIR/../src/*.go


### PR DESCRIPTION
The README says I can run `./scripts/build.sh`, but when I do I get the following error:
`src/*.go: directory not found`
I can only run the script from the `scripts` directory.

This pull request fixes this behavior and allows the script to be run from the root of the repository.